### PR TITLE
docs: fix typos and formatting across multiple documentation files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,29 +79,29 @@ All components remain experimental.
 
 ### Highlights
 - Made a functioning official site of xLaDe available at "http://xladeajfgkh32qgq5sj2mtmho3te5pivto7lav44dsbov6uduciz6hqd.onion/"
-- Added project on gitlab at "https://gitlab.com/lakshitsinghbishttm/xLaDe". Both github and gitlab versions will be synced.
+- Added project on GitLab at "https://gitlab.com/lakshitsinghbishttm/xLaDe". Both GitHub and GitLab versions will be synced.
 
 ### Added
 - Rationale behind choosing an onion site for xLaDe.
-- New examples of lean to try in xlade.
+- New examples of Lean to try in xLaDe.
 - Dedicated security folder.
 
 ### Changed
-- Docs to focus on the xlade functioning, limitations, contributions and readme.
+- Docs to focus on the xLaDe functioning, limitations, contributions and README.
 
 ### Notes
-This monthly release focuses mainly on organisation and official site of xLaDe and its integration with github repo instead of major code changes. xLaDe still is in its experimental stage.
+This monthly release focuses mainly on organization and official site of xLaDe and its integration with GitHub repo instead of major code changes. xLaDe still is in its experimental stage.
 
 ## [1.4.0] — 2026-04-27
 
 ### Highlights
-- Added metadata for each experiment to support backward compatibility in future (ongoing long term idea)
-- Modified cli tool to run experiments
+- Added metadata for each experiment to support backward compatibility in the future (ongoing long-term idea)
+- Modified CLI tool to run experiments
 
 ### Added
-- Mirrors to support decentralisation and reduce redundancy
+- Mirrors to support decentralization and reduce redundancy
 - Structured tools module
 - Docs explaining roadmap regarding backward compatibility
 
 ### Notes
-This monthly release makes cli tool execute experiments, but the testing of xlade cli hasn't been done properly, so problems may occur.
+This monthly release makes the CLI tool execute experiments, but the testing of the xLaDe CLI hasn't been done properly, so problems may occur.

--- a/HOW_TO_READ_THIS_REPO.md
+++ b/HOW_TO_READ_THIS_REPO.md
@@ -45,7 +45,7 @@ None of these modify Lean’s kernel or core semantics.
 ## Intentionally Minimal Components
 
 - CLI execution
-- Qualitative metrices
+- Qualitative metrics
 - Few experiments
 - Lean code
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -24,7 +24,7 @@ git clone https://github.com/LakshitSinghBishtTM/xLaDe.git
 cd xLaDe
 ```
 
-Build with lake
+Build with Lake:
 
 ```
 lake update

--- a/MIRRORS.md
+++ b/MIRRORS.md
@@ -14,7 +14,7 @@ Mirrors are part of the project's distribution strategy, but they are **not auth
 
 * https://gitlab.com/LakshitSinghBishtTM/xLaDe
 
-### Codeburg
+### Codeberg
 
 * https://codeberg.org/lakshitsinghbishttm/xLaDe
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Known limitations:
 - [`LIMITATIONS.md`](LIMITATIONS.md)
 
 Security and boundary assumptions:
-- [`THREAT_MODEL.md`](THREAT_MODEL.md)
+- [`THREAT_MODEL.md`](security/THREAT_MODEL.md)
 
 ---
 
@@ -71,7 +71,7 @@ For details on trust, verification, and distribution:
 
 - [Official Sources](./OFFICIAL_SOURCES.md)
 - [Onion Service](./ONION.md)
-- [Security Model](./SECURITY_POLICY.md)
+- [Security Model](./security/SECURITY_POLICY.md)
 
 ---
 
@@ -135,7 +135,7 @@ xLaDe/
 ├── LICENSE               License information
 ├── README.md             Project overview
 └── VERSION               Current version
-````
+```
 
 ---
 
@@ -261,7 +261,7 @@ Copyright (C) 2026 Lakshit Singh Bisht
 
 This project is licensed under the GNU General Public License v3.0. See LICENSE for details.
 
-```Note: This project depends on Lean 4, which is licensed under the Apache License 2.0 and is included unmodified.```
+> **Note:** This project depends on Lean 4, which is licensed under the Apache License 2.0 and is included unmodified.
 
 ---
 
@@ -271,8 +271,8 @@ xLaDe is **experimental**.
 
 As of `v1.4.0`:
 
-* Primary focus is on mirrors and decentralisation currently
-* Experiments metadata is being collected at repo level to help in backward compatibility 
-* cli based app is still not stable
+* Primary focus is on mirrors and decentralization currently
+* Experiment metadata is being collected at repo level to help in backward compatibility
+* CLI-based app is still not stable
 
 xLaDe exists as a living laboratory for Lean ecosystem design.

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -42,17 +42,17 @@ This file mirrors GitHub Releases for archival and offline reference.
 
 ### Highlights
 - Added a few examples for support in further experiments.
-- Modified and improved documents regarding prerequisites of xlade, its use, contributions and README.
+- Modified and improved documents regarding prerequisites of xLaDe, its use, contributions and README.
 - Made the official site of xLaDe, available at "http://xladeajfgkh32qgq5sj2mtmho3te5pivto7lav44dsbov6uduciz6hqd.onion/". 
 - Clarification added regarding why an onion site was chosen instead of a random site, along with other documents.
 - Added a dedicated folder for security instead of adding files directly in root folder, added two new documents
-- Imported project to gitlab for long term availability and usefulness. Added mirror list for officially suppported mirrors.
+- Imported project to GitLab for long-term availability and usefulness. Added mirror list for officially supported mirrors.
 
 ## v1.4.0 - 2026-04-27
 
 ### Highlights
-- Added .toml for recording metadata in each experiments
-- Modified cli tool for running experiments
+- Added .toml for recording metadata in each experiment
+- Modified CLI tool for running experiments
 - Added and configured mirrors to sync automatically (sourceforge remaining)
 - Restructured tools section for future modifications
 - Regular improvements in docs for updated info

--- a/docs/CLI_DEMO.md
+++ b/docs/CLI_DEMO.md
@@ -29,7 +29,7 @@ Many execution backends are intentionally **lightweight or stubbed** at this sta
 
 ## Note:
 
-Please download and build the Lean with lake, and other requirements before running xLaDe already explained in other docs, otherwise xLaDe won't run properly.
+Please download and build Lean with Lake, and fulfil the other requirements explained in other docs, before running xLaDe, otherwise xLaDe won't run properly.
 
 ## 1. Project Initialization
 

--- a/docs/END_TO_END_TRACE.md
+++ b/docs/END_TO_END_TRACE.md
@@ -77,7 +77,7 @@ Note:
 This command removes only xLaDe’s project-local state directory.
 
 Dev Note:
-Do NOT run ```sudo rm -rf /``` unless you want to delete entire the entire system, including the OS, users, and your hopes.
+Do NOT run ```sudo rm -rf /``` unless you want to delete the entire system, including the OS, users, and your hopes.
 
 Effect:
 

--- a/docs/RUNTIME_STATE.md
+++ b/docs/RUNTIME_STATE.md
@@ -26,7 +26,7 @@ Global state is stored in the user’s home directory:
 
 ```
 ~/.xlade/
-````
+```
 
 This directory contains **user-wide configuration and mode selection**.
 

--- a/metrics/README.md
+++ b/metrics/README.md
@@ -52,7 +52,7 @@ metrics/
   README.md
   summary.md
   <metric-definition>.md
-````
+```
 
 Metric definitions are intentionally lightweight and descriptive at this stage.
 They may later be accompanied by structured data or automated collection tools.

--- a/modes/README.md
+++ b/modes/README.md
@@ -92,7 +92,7 @@ The active mode is set globally via:
 
 ```
 xlade mode <onboarding|experimental|stable>
-````
+```
 
 The selected mode is stored in:
 

--- a/projects/demo/README.md
+++ b/projects/demo/README.md
@@ -27,7 +27,7 @@ Before running the demo, ensure that:
 
 ```
 chmod +x bin/xlade
-````
+```
 
 ---
 

--- a/security/SECURITY_POLICY.md
+++ b/security/SECURITY_POLICY.md
@@ -27,7 +27,7 @@ At this stage of the project:
 
 ## Reporting a Vulnerability
 
-Please refer to `docs/SECURITY.md`
+Please refer to `security/SECURITY.md`
 
 ---
 

--- a/security/TRUST_MODEL.md
+++ b/security/TRUST_MODEL.md
@@ -52,12 +52,12 @@ The threat model for xLaDe is defined with respect to its intended use as a loca
 
 The primary assets of interest are:
 
-* Integrity of the Lean~4 proof kernel
+* Integrity of the Lean 4 proof kernel
 * Correctness of proof verification
 
 #### Trusted Components
 
-* Lean4 kernel
+* Lean 4 kernel
 * Lean compiler and core toolchain
 
 These components are assumed to be correct and not adversarially modified.


### PR DESCRIPTION
Hi! I'm a new contributor. I've fixed several typos (such as 'metrices' and 'codeburg') and improved capitalization/formatting consistency in the core documentation files to help new users.