### PR TITLE
Fix typos and grammar in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ See:
 
 ## Using xLaDe
 
-xLaDe provides a lightweight CLI. Run these from root directory:
+xLaDe provides a lightweight CLI. Run these from the root directory:
 
 ```
 ./bin/xlade init
@@ -244,7 +244,7 @@ See:
 
 ## Contributing
 
-Contributions are heartily welcome to help in our project.
+Contributions are welcome!
 
 See:
 


### PR DESCRIPTION
"Fixed a missing 'the' before 'root directory' and improved phrasing in the Contributing section of README.md"