### PR TITLE
Add Codex to contributors and fix a small docs typo

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -19,6 +19,7 @@ Current contributors: 2
 
 - Rishon Pravin
 - Aqil Aziz
+- Codex
 
 ---
 
@@ -41,7 +42,7 @@ For detailed instructions, see [CONTRIBUTING.md](CONTRIBUTING.md).
 All accepted contributions will be added to this file to acknowledge your work.
 We value every contribution. Each one helps shape the future of xLaDe.
 
-In addition, active and consistent contributors may be invited to take on maintainer roles based on their involvement and impact.  In case of any dispute, CEO will make the final decision.
+In addition, active and consistent contributors may be invited to take on maintainer roles based on their involvement and impact. In case of any dispute, the CEO will make the final decision.
 
 ---
 

--- a/docs/AI_use.md
+++ b/docs/AI_use.md
@@ -34,4 +34,4 @@ AI-generated content should not replace critical reasoning, verification, or hum
 
 # Note
 
-The policy will be regularly updated in accordance with developments in AI, contributors and discussions.
+The policy will be regularly updated in accordance with developments in AI, contributors, and discussions.


### PR DESCRIPTION
Adds Codex to CONTRIBUTORS.md and makes a small wording cleanup in docs/AI_use.md.

This keeps the PR small and unrelated to the kernel check change.