### PR TITLE
Add simple logic Lean example

### DIFF
--- a/examples/logic_implication.lean
+++ b/examples/logic_implication.lean
@@ -1,0 +1,5 @@
+-- A simple logical implication proof
+
+theorem implies_self (p : Prop) : p → p := by
+  intro hp
+  exact hp


### PR DESCRIPTION
Adds a simple logical implication proof to the examples/ module.

The theorem shows that every proposition implies itself.